### PR TITLE
Fix: getGithubUsername.js / 

### DIFF
--- a/lib/utils/getGithubUsername.js
+++ b/lib/utils/getGithubUsername.js
@@ -4,10 +4,19 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.getGithubUsername = void 0;
 const child_process_1 = require("child_process");
 const getGithubUsername = () => {
-  const gitUrl = (0, child_process_1.execSync)("git config --get user.email")
+  const gitUserEmail = (0, child_process_1.execSync)("git config --get user.email")
     .toString()
     .trim();
-  const githubId = gitUrl.split("@")[0].split("+")[1];
-  return githubId;
+
+  const gitUserNameStr = (0, child_process_1.execSync)("git config --get user.name")
+      .toString()
+      .trim();
+
+  const getValidGithubId = (email) => {
+    const local = email.split("@")[0];
+    return local.includes("+") ? local.split("+")[1] : local;
+  }
+
+  return getValidGithubId(gitUserEmail);
 };
 exports.getGithubUsername = getGithubUsername;


### PR DESCRIPTION
1. git config로부터 불러온 user.email string 에 +가 없는 경우 path에 들어가는 username parameter 가 undefined 인 문제를 수정했습니다.
2. 현재 user.email 의 local 부분을 개인 directory 명으로 설정하고 있는데, git user.name 을 사용하시는 건 어떠신가요?